### PR TITLE
Modify sPlot to include support as input and include function for sWe…

### DIFF
--- a/src/sWeights-extra.jl
+++ b/src/sWeights-extra.jl
@@ -17,15 +17,15 @@ then compute sWeights and their variances for each event.
 - `sP`: The fitted sPlot object.
 - `n_signal`, `n_background`: Fitted yields.
 - `cov`: Covariance matrix of yields.
-- `ws`, `wb`: sWeights for signal and background (vectors).
-- `vs`, `vb`: Variances of sWeights (vectors).
+- `W`: sWeight vector with signal and background sWeights.
+- `V`: Variance vector with variance of sWeights.
 
 # Example
 ```julia
 pdfS = Normal(0, 1)
 pdfB = Normal(5, 1.5)
 data = vcat(rand(pdfS, 40), rand(pdfB, 60))
-result, sP, nS, nB, cov, ws, wb, vs, vb = fit_and_sWeights(pdfS, pdfB, data)
+result, sP, nS, nB, cov, W, V = fit_and_sWeights(pdfS, pdfB, data)
 # Use sP for further sWeight calculations:
 wS, wB = sWeights(sP, data) |> eachcol
 fS(x) = sWeights(sP, [x])[1,1]
@@ -62,8 +62,8 @@ function fit_and_sWeights(pdfS, pdfB, data; support = nothing, init_fsig = 0.5)
     cov = inv(hess)
 
     # Compute sWeights and variances using the sPlot object
-    ws, wb, vs, vb = sWeights_vector_with_variance(sP, data)
+    W, V = sWeights_vector_with_variance(sP, data)
 
-    return result, sP, nS, nB, cov, ws, wb, vs, vb
+    return result, sP, nS, nB, cov, W, V
 end
 

--- a/src/sweights.jl
+++ b/src/sweights.jl
@@ -1,12 +1,12 @@
 """
-    sPlot(model::MixtureModel)
+    sPlot(model::MixtureModel; support=nothing)
 
 Encapsulates the sPlot decomposition for a mixture model.
 
 # Fields
 - `model`: The `MixtureModel` (from Distributions.jl).
 - `inv_W`: The inverse sPlot weight matrix (covariance of yields).
-
+- 'support' : If nothing provided, get support from model components.
 # Example
 ```julia
 pdfS = Normal(0, 1)
@@ -19,11 +19,11 @@ struct sPlot{M, T}
     model::M
     inv_W::Matrix{T}
     #
-    function sPlot(model::MixtureModel)
+    function sPlot(model::MixtureModel; support=nothing)
         comps = model.components
         weights = model.prior.p
         f(x) = sum(weights[i] * pdf(comps[i], x) for i in eachindex(comps))
-        lims = (minimum([minimum(support(c)) for c in comps]), maximum([maximum(support(c)) for c in comps]))
+        lims = isnothing(support) ? (minimum([minimum(support(c)) for c in comps]), maximum([maximum(support(c)) for c in comps])) : support
         ϵ = 1e-12
         W = [quadgk(x -> pdf(ci, x) * pdf(cj, x) / max(f(x), ϵ), lims...)[1]
              for ci in comps, cj in comps]
@@ -98,10 +98,11 @@ function sWeights(
     pdfS::UnivariateDistribution,
     pdfB::UnivariateDistribution,
     fraction_signal::Real,
-    xs::AbstractVector,
+    xs::AbstractVector;
+    support=nothing
 )
     model = MixtureModel([pdfS, pdfB], [fraction_signal, 1 - fraction_signal])
-    sP = sPlot(model)
+    sP = sPlot(model;support=support)
     return sWeights(sP, xs)
 end
 
@@ -135,11 +136,47 @@ function sWeights(
     pdfB::UnivariateDistribution,
     n_signal::Real,
     n_background::Real,
-    xs::AbstractVector,
+    xs::AbstractVector;
+    support=nothing
 )
     N = n_signal + n_background
     f_signal = n_signal / N
-    return sWeights(pdfS, pdfB, f_signal, xs)
+    return sWeights(pdfS, pdfB, f_signal, xs;support=support)
+end
+
+"""
+    sWeights(pdfs::Vector{<:UnivariateDistribution},fractions::Vector{<:Real},xs::AbstractVector;support=nothing)
+
+Compute the sWeight functions for set of pdf components using the fitted fractions for each component
+
+# Arguments
+- `pdfs` : Vector of different models (as `UnivariateDistribution`). Its highly recommended to follow the template `[signal,background,lineshapes]`
+- `fractions` : Vector of fit fractions for each component (must be non-negative, all fractions must sum to 1). Pleasure ensure that `length(pdfs) == length(fractions)`
+
+# Returns
+- `weights` : Matrix of size (length(xs), n_components), where each column is the sWeights for a component
+
+# Example
+```julia
+pdfs = [Normal(0,1),Normal(3,1.5),Normal(5,0.001)]
+fractions = [0.4,0.55,0.05]
+support = (-10,10)
+x = vcat(rand(pdfa[1], 40), rand(pdfs[2], 55), rand(pdfs[3],5))
+wS, wB, wL = sWeights(pdfs, fractions, x) |> eachcol
+fS(x) = sWeights(sP, [x])[1,1]
+fB(x) = sWeights(sP, [x])[1,2]
+fL(x) = sWeights(sP, [x])[1,3]
+```
+"""
+function sWeights(
+    pdfs::Vector{<:UnivariateDistribution},
+    fractions::Vector{<:Real},
+    xs::AbstractVector;
+    support=nothing
+)
+    model = MixtureModel(pdfs,fractions)
+    sP = sPlot(model;support=support)
+    return sWeights(sP,xs)
 end
 
 """
@@ -210,9 +247,9 @@ pdfB = Normal(5, 1.5)
 cov = inv_W(pdfS, pdfB, 0.4)
 ```
 """
-function inv_W(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real)
+function inv_W(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real;support=nothing)
     model = MixtureModel([pdfS, pdfB], [fraction_signal, 1 - fraction_signal])
-    sP = sPlot(model)
+    sP = sPlot(model;support=support)
     return inv_W(sP)
 end
 
@@ -314,8 +351,8 @@ xs = [-2.0, 0.0, 5.0, 8.0]
 ws, wb, vs, vb = sWeights_vector_with_variance(pdfS, pdfB, 0.4, xs)
 ```
 """
-function sWeights_vector_with_variance(pdfS, pdfB, fraction_signal, xs)
+function sWeights_vector_with_variance(pdfS, pdfB, fraction_signal, xs;support=nothing)
     model = MixtureModel([pdfS, pdfB], [fraction_signal, 1 - fraction_signal])
-    sP = sPlot(model)
+    sP = sPlot(model;support=support)
     return sWeights_vector_with_variance(sP, xs)
 end

--- a/src/sweights.jl
+++ b/src/sweights.jl
@@ -158,7 +158,7 @@ Compute the sWeight functions for set of pdf components using the fitted fractio
 
 # Example
 ```julia
-pdfs = [Normal(0,1),Normal(3,1.5),Normal(5,0.001)]
+pdfs = [Normal(0,1),Normal(3,1.5),Normal(5,0.1)]
 fractions = [0.4,0.55,0.05]
 support = (-10,10)
 x = vcat(rand(pdfa[1], 40), rand(pdfs[2], 55), rand(pdfs[3],5))

--- a/src/sweights.jl
+++ b/src/sweights.jl
@@ -23,7 +23,7 @@ struct sPlot{M, T}
         comps = model.components
         weights = model.prior.p
         f(x) = sum(weights[i] * pdf(comps[i], x) for i in eachindex(comps))
-        lims = isnothing(support) ? (minimum([minimum(support(c)) for c in comps]), maximum([maximum(support(c)) for c in comps])) : support
+        lims = isnothing(support) ? (minimum([minimum(Distributions.support(c)) for c in comps]), maximum([maximum(Distributions.support(c)) for c in comps])) : support
         ϵ = 1e-12
         W = [quadgk(x -> pdf(ci, x) * pdf(cj, x) / max(f(x), ϵ), lims...)[1]
              for ci in comps, cj in comps]

--- a/src/sweights.jl
+++ b/src/sweights.jl
@@ -73,7 +73,7 @@ function sWeights(sP::sPlot, xs::AbstractVector)
 end
 
 """
-    sWeights(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real, xs::AbstractVector)
+    sWeights(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real, xs::AbstractVector;support=nothing)
 Computes the sWeight functions for signal and background components
 based on individual distributions.
 # Arguments
@@ -107,7 +107,7 @@ function sWeights(
 end
 
 """
-    sWeights(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, n_signal::Real, n_background::Real, xs::AbstractVector)
+    sWeights(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, n_signal::Real, n_background::Real, xs::AbstractVector; support=nothing)
 
 Compute the sWeight functions for signal and background components using the absolute fitted yields.
 
@@ -228,7 +228,7 @@ function inv_W(sP::sPlot)
 end
 
 """
-    inv_W(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real)
+    inv_W(pdfS::UnivariateDistribution, pdfB::UnivariateDistribution, fraction_signal::Real;support=nothing)
 
 Return the covariance matrix for a two-component mixture model.
 
@@ -292,7 +292,7 @@ Compute the sWeights and their variances for data points using the sPlot object.
 - `xs`: Vector of data points.
 
 # Returns
-- `(ws_signal, ws_background, var_signal, var_background)`: Tuple of vectors containing the sWeights and their variances for each component.
+- `weights,variances`: Two vectors containing vectors of sWeights and variance for each component.
 
 # Example
 ```julia
@@ -301,13 +301,10 @@ pdfB = Normal(5, 1.5)
 model = MixtureModel([pdfS, pdfB], [0.4, 0.6])
 sP = sPlot(model)
 xs = [-2.0, 0.0, 5.0, 8.0]
-ws, wb, vs, vb = sWeights_vector_with_variance(sP, xs)
+W,V = sWeights_vector_with_variance(sP, xs)
 ```
 """
 function sWeights_vector_with_variance(sP::sPlot, xs)
-    weights = sWeights(sP, xs)
-    wS, wB = eachcol(weights)
-
     # Variance calculation
     V = sP.inv_W
     comps = sP.model.components
@@ -323,14 +320,14 @@ function sWeights_vector_with_variance(sP::sPlot, xs)
         return v / (f(x)^2)
     end
 
-    vS = [variance(1, x) for x in xs]
-    vB = [variance(2, x) for x in xs]
+    weights = [sWeights(sP, xs)[:,i] for i in eachindex(comps)]
+    variances = [[variance(i,x) for x in xs] for i in eachindex(comps)]
 
-    return (wS, wB, vS, vB)
+    return weights,variances
 end
 
 """
-    sWeights_vector_with_variance(pdfS, pdfB, fraction_signal, xs)
+    sWeights_vector_with_variance(pdfS, pdfB, fraction_signal, xs;support=nothing)
 
 Compute the sWeights and their variances for data points using individual distributions.
 
@@ -341,14 +338,14 @@ Compute the sWeights and their variances for data points using individual distri
 - `xs`: Vector of data points.
 
 # Returns
-- `(ws_signal, ws_background, var_signal, var_background)`: Tuple of vectors containing the sWeights and their variances.
+- `weights,variances`: Two vectors containing vectors of sWeights and variance for each component.
 
 # Example
 ```julia
 pdfS = Normal(0, 1)
 pdfB = Normal(5, 1.5)
 xs = [-2.0, 0.0, 5.0, 8.0]
-ws, wb, vs, vb = sWeights_vector_with_variance(pdfS, pdfB, 0.4, xs)
+W, V = sWeights_vector_with_variance(pdfS, pdfB, 0.4, xs)
 ```
 """
 function sWeights_vector_with_variance(pdfS, pdfB, fraction_signal, xs;support=nothing)

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -127,7 +127,7 @@ end
 
     # Create sPlot object
     model = MixtureModel([pdfS, pdfB], [f_signal, 1 - f_signal])
-    sP = sPlot(model)
+    sP = sPlot(model)i
 
     # Test sWeights function access
     fS(x) = sWeights(sP, [x])[1, 1]
@@ -149,6 +149,29 @@ end
     # Test condition number
     condW = check_wMatrix_condition(sP)
     @test condW > 0
+end
+
+@testset "sWeights from functions" begin
+    pdfS = Normal(0, 1)
+    pdfB = Normal(5, 1.5)
+    nS, nB = 40, 60
+    xs = [-2.0, 0.0, 5.0, 8.0]
+    f_signal = nS / (nS+nB)
+
+    #Get sWeights from function taking fraction as input
+    wS_from_fraction,wB_from_fraction = sWeights(pdfS,pdfB,f_signal,xs) |> eachcol
+
+    #Get sWeights from function taking yields as input
+    wS_from_yields,wB_from_yields = sWeights(pdfS,pdfB,nS,nB,xs) |> eachcol
+
+    #Compare the two weight arrays
+    @test wS_from_fraction == wS_from_yields
+    @test wS_from_fraction == wS_from_yields
+
+    #Test covariance matrix, calculated using pdfs and f_signal
+    cov = inv_W(pdfS,pdfB,f_signal,xs)
+    @test size(cov) == (2,2)
+    @test cov[1,1] > 0
 end
 
 @testset "sWeights from array of pdfs" begin
@@ -183,7 +206,9 @@ end
     xs = [-2.0, 0.0, 5.0, 8.0]
 
     # Test with individual distributions
-    ws, wb, vs, vb = sWeights_vector_with_variance(pdfS, pdfB, 0.4, xs)
+    W,V = sWeights_vector_with_variance(pdfS, pdfB, 0.4, xs)
+    (ws,wb) = W
+    (vs,vb) = V
     @test length(ws) == length(xs)
     @test length(vs) == length(xs)
     @test all(vs .>= 0)

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -127,7 +127,7 @@ end
 
     # Create sPlot object
     model = MixtureModel([pdfS, pdfB], [f_signal, 1 - f_signal])
-    sP = sPlot(model)i
+    sP = sPlot(model)
 
     # Test sWeights function access
     fS(x) = sWeights(sP, [x])[1, 1]

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -220,7 +220,7 @@ end
     # Test with sPlot object
     model = MixtureModel([pdfS, pdfB], [0.4, 0.6])
     sP = sPlot(model)
-    W2,V2 = sWeights_vector_with_variance(sP xs)
+    W2,V2 = sWeights_vector_with_variance(sP,xs)
     (ws2,wb2) = W2
     (vs2,vb2) = V2
     @test ws ≈ ws2 atol = 1e-10

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -220,7 +220,9 @@ end
     # Test with sPlot object
     model = MixtureModel([pdfS, pdfB], [0.4, 0.6])
     sP = sPlot(model)
-    ws2, wb2, vs2, vb2 = sWeights_vector_with_variance(sP, xs)
+    W2,V2 = sWeights_vector_with_variance(sP xs)
+    (ws2,wb2) = W2
+    (vs2,vb2) = V2
     @test ws ≈ ws2 atol = 1e-10
     @test wb ≈ wb2 atol = 1e-10
     @test vs ≈ vs2 atol = 1e-10

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -169,7 +169,7 @@ end
     @test wS_from_fraction == wS_from_yields
 
     #Test covariance matrix, calculated using pdfs and f_signal
-    cov = inv_W(pdfS,pdfB,f_signal,xs)
+    cov = inv_W(pdfS,pdfB,f_signal)
     @test size(cov) == (2,2)
     @test cov[1,1] > 0
 end

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -152,7 +152,7 @@ end
 end
 
 @testset "sWeights from array of pdfs" begin
-    pdfs = [Normal(0,1),Normal(3,0.5),Normal(5,0.001)]
+    pdfs = [Normal(0,1),Normal(3,0.5),Normal(5,0.1)]
     fractions = [0.4,0.55,0.05]
     xs = [-2.0,0.0,3.0,-7.0,5.0,8.0]
     support = (-10,10)

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -233,8 +233,9 @@ end
     pdfS = Normal(0, 1)
     pdfB = Normal(5, 1.5)
     data = vcat(rand(pdfS, 40), rand(pdfB, 60))
-    result, sP, nS, nB, cov, ws, wb, vs, vb = fit_and_sWeights(pdfS, pdfB, data)
-
+    result, sP, nS, nB, cov, W, V = fit_and_sWeights(pdfS, pdfB, data)
+    (ws,wb) = W
+    (vs,vb) = V
     # Basic checks
     @test all(vs .>= 0)
     @test all(vb .>= 0)

--- a/test/test-sweights.jl
+++ b/test/test-sweights.jl
@@ -151,6 +151,32 @@ end
     @test condW > 0
 end
 
+@testset "sWeights from array of pdfs" begin
+    pdfs = [Normal(0,1),Normal(3,0.5),Normal(5,0.001)]
+    fractions = [0.4,0.55,0.05]
+    xs = [-2.0,0.0,3.0,-7.0,5.0,8.0]
+    support = (-10,10)
+
+    # Create sPlot object
+    model = MixtureModel(pdfs,fractions)
+    sP = sPlot(model;support=support)
+
+    # Test sPlot object
+    @test sP.model == model
+    @test size(sP.inv_W) == (3, 3)
+
+    # Test sWeights function
+    weights = sWeights(pdfs,fractions,xs;support=support)
+    ws,wb,wl = eachcol(weights)
+    @test length(ws) == length(xs)
+    @test length(wb) == length(xs)
+    @test length(wl) == length(xs)
+    # sWeights should sum to about 1 for pure regions
+    @test ws[2] ≈ 1.0 atol = 0.1 # near pure signal
+    @test wb[3] ≈ 1.0 atol = 0.1 # near pure background
+    @test wl[5] ≈ 1.0 atol = 0.1 # near pure lineshape
+end
+
 @testset "sWeights_vector_with_variance" begin
     pdfS = Normal(0, 1)
     pdfB = Normal(5, 1.5)


### PR DESCRIPTION
I am suggesting two changes based on the discussions I had with Marian and Ilya yesterday:
1) Provide an additional functionality of ```support``` as a keyword argument to ```sPlot```. This ensures the weight matrix does not go to zero matrix in case where models have infinite support (like Gaussian)
2) Add a function for sWeights where you can pass an array of pdfs and respective fit fractions as input and get sWeights for each pdf component seperately. Recommended template for this is ```[SignalPDF,BackgroundPDF,LineShapePDFs...]```.